### PR TITLE
refactor to pull configurations from .env instead of config file

### DIFF
--- a/src/library/context.py
+++ b/src/library/context.py
@@ -1,4 +1,5 @@
 import pendulum
+import os
 from .helpers.s3_resource import S3_resource
 from .helpers.fs_resource import FS_resource
 
@@ -7,11 +8,30 @@ datastores = {
     "filesystem": FS_resource
 }
 
-class Context:
-    def __init__(self, config):
-        self.config = config
-        self.datastore = datastores[config["datastore"]["name"]](config["datastore"]["path"])
-        self.tmp = FS_resource(config["tmp_dir"])
+evKeys = [
+    "LOCAL_DATA",
+    "DATASTORE_NAME",
+    "DATASTORE_PATH",
+    "TMP_DIR",
+    "METRO_LINES",
+    "METRO_AGENCY",
+    "TIMEZONE",
+    "SCHEDULE_URL",
+    "VEHICLE_API_URL"
+]
 
+class Context:
+    def __init__(self):
+        self.config = {}
+
+        for k in evKeys: 
+           self.config[k]=os.environ[k]
+        
+        self.config["METRO_LINES"] = [int(line) for line in self.config["METRO_LINES"].split(",")]
+        print(self.config)
+        self.datastore = datastores[self.config["DATASTORE_NAME"]](self.config["DATASTORE_PATH"])
+        self.tmp = FS_resource(self.config["TMP_DIR"])
+        print(self.config)
+        
     def logger(self, stuff, datetime=pendulum.now()):
         print(datetime, stuff, sep=",")

--- a/src/library/get_schedule.py
+++ b/src/library/get_schedule.py
@@ -4,10 +4,10 @@ import requests
 from zipfile import ZipFile
 
 def get_schedule(ctx):
-    url = ctx.config["schedule_url"]
+    url = ctx.config["SCHEDULE_URL"]
     response = requests.get(url)
     zf = ZipFile(io.BytesIO(response.content))
-    path = os.path.join(ctx.config["tmp_dir"], "GTFS")
+    path = os.path.join(ctx.config["TMP_DIR"], "GTFS")
     os.makedirs(path, exist_ok=True)
     zf.extractall(path)
     return 0

--- a/src/library/get_vehicles.py
+++ b/src/library/get_vehicles.py
@@ -5,9 +5,9 @@ import requests
 import pendulum
 
 def get_vehicles(ctx):
-    agency = ctx.config["metro_agency"]
-    lines = ctx.config["metro_lines"]
-    base_url = ctx.config["vehicle_api_url"]
+    agency = ctx.config["METRO_AGENCY"]
+    lines = ctx.config["METRO_LINES"]
+    base_url = ctx.config["VEHICLE_API_URL"]
     for line in lines:
         data = get_vehicles_for_line(base_url, agency, line)
         ctx.tmp.write_json(f"tracking/{agency}/{line}/latest.json", data)

--- a/src/library/prepare_vehicles.py
+++ b/src/library/prepare_vehicles.py
@@ -2,8 +2,8 @@ import pandas as pd
 from library.analysis.nextbus import NextBusData
 
 def prepare_vehicles(ctx):
-    lines = ctx.config["metro_lines"]
-    agency = ctx.config["metro_agency"]
+    lines = ctx.config["METRO_LINES"]
+    agency = ctx.config["METRO_AGENCY"]
     for line in lines:
         data = ctx.tmp.load_json(f"tracking/{agency}/{line}/latest.json")
         try:

--- a/src/library/process_schedule.py
+++ b/src/library/process_schedule.py
@@ -5,8 +5,8 @@ from .analyzer.calendar import Calendar
 from .analyzer.schedule import scheduleTimeToDateTime
 
 def process_schedule(ctx, datetime):
-    agency = ctx.config["metro_agency"]
-    start_date = datetime.in_tz(ctx.config["timezone"]).format("YYYY-MM-DD")
+    agency = ctx.config["METRO_AGENCY"]
+    start_date = datetime.in_tz(ctx.config["TIMEZONE"]).format("YYYY-MM-DD")
 
     # Load all data
     full_schedule = pd.read_csv(ctx.tmp.get_abs_path("GTFS/stop_times.txt"))

--- a/src/library/process_vehicles.py
+++ b/src/library/process_vehicles.py
@@ -8,13 +8,13 @@ from library.analyzer.process_vehicles import (
 from library.helpers.timing import get_appropriate_timetable
 
 def process_vehicles(ctx, datetime):
-    agency = ctx.config["metro_agency"]
-    lines = ctx.config["metro_lines"]
-    date = datetime.in_tz(ctx.config["timezone"]).format("YYYY-MM-DD")
+    agency = ctx.config["METRO_AGENCY"]
+    lines = ctx.config["METRO_LINES"]
+    date = datetime.in_tz(ctx.config["TIMEZONE"]).format("YYYY-MM-DD")
     for line in lines:
         path = ctx.tmp.get_abs_path(f"tracking/{agency}/{line}/preprocessed.csv")
         df = pd.read_csv(path, index_col=0)
-        tracks = get_track(line, ctx.config["local_data"])
+        tracks = get_track(line, ctx.config["LOCAL_DATA"])
         processed = process_raw_vehicles(df, tracks)
         ctx.tmp.write(f"tracking/{agency}/{line}/processed.csv", processed.to_csv())
     return 0

--- a/src/main.py
+++ b/src/main.py
@@ -5,8 +5,7 @@ from library.context import Context
 from actions import ACTIONS
 
 def main(command, datetime=None):
-    with open('fs_config.json', 'r') as infile:
-        ctx = Context(json.load(infile))
+    ctx = Context()
     datetime = pendulum.now()
 
     outcome = ACTIONS[command](ctx, datetime)


### PR DESCRIPTION
By making use of a .env file, we can ensure that any future docker images we host are secure and portable.