### PR TITLE
restructure Dockerfile to take advantage of layer caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,12 @@ RUN apt-get update && apt-get install -y \
   libproj-dev \
   libgeos-dev
 
-COPY ./src /app/src
+COPY ./requirements.txt /app/requirements.txt
+WORKDIR /app
+RUN pip install -r /app/requirements.txt
+
 COPY ./data/GIS /app/data/GIS
 COPY ./data/line_info /app/data/line_info
 COPY ./tests /app/tests
-COPY ./requirements.txt /app/requirements.txt
 COPY ./tasks /app/tasks
-
-WORKDIR /app
-
-RUN pip install -r /app/requirements.txt
+COPY ./src /app/src


### PR DESCRIPTION
Structuring the Dockerfile by installing dependencies first and copying in source code later means when we rebuild the Docker image after source code changes, we don't need to reinstall dependencies (which takes ages!!).